### PR TITLE
Fix (ci): Fix converge-master-and-release-branches job to use fetch-depth 0 in release-ci workflow

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -223,6 +223,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Merge release into master (fast-forward)
         run: |
           git checkout master


### PR DESCRIPTION
To be able to use git merge